### PR TITLE
Fix ajax issue when admin url contains 'index.php'

### DIFF
--- a/js/hackathon_indexerstats/index_progress.js
+++ b/js/hackathon_indexerstats/index_progress.js
@@ -60,7 +60,7 @@ IndexerStats.Status.prototype = {
     update : function() {
         if (this.isUpdating) return;
         this.isUpdating = true;
-        new Ajax.Request('/admin/process/statusAjax', {
+        new Ajax.Request(window.location.href.replace('/process/list','/process/statusAjax'), {
             loaderArea : false,
             onSuccess : this.onSuccess.bind(this),
             onFailure : this.onFailure.bind(this)


### PR DESCRIPTION
When the admin url contains `index.php` the ajax request to
`'/admin/process/statusAjax’` will be failed.

![Ajax 404 Failed](http://image.prntscr.com/image/a071f7331e024d81bef3f3695fe7b885.png)
